### PR TITLE
Release v0.0.14-alpha-beta2-uroesch

### DIFF
--- a/App/AppInfo/appinfo.ini
+++ b/App/AppInfo/appinfo.ini
@@ -45,5 +45,5 @@ ShellCommand=
 [FileTypeIcons]
 
 [Version]
-PackageVersion=0.0.13.0
-DisplayVersion=0.0.13-alpha-beta2-uroesch
+PackageVersion=0.0.14.0
+DisplayVersion=0.0.14-alpha-beta3-uroesch

--- a/App/AppInfo/update.ini
+++ b/App/AppInfo/update.ini
@@ -1,9 +1,17 @@
 [Version]
-Package = 0.0.13.0
-Display = 0.0.13-alpha-beta2-uroesch
+Package = 0.0.14.0
+Display = 0.0.14-alpha-beta3-uroesch
 
 [Archive]
-URL1         = https://github.com/uroesch/PlinkProxy/releases/download/v0.0.13-alpha/PlinkProxy_v0.0.13-alpha.zip
-Checksum1    = SHA256:44E2E24C28D20B8B52B27AED369577BFB40F2E7928EB6C43DB018579B5580CD3
+URL1         = https://github.com/uroesch/PlinkProxy/releases/download/v0.0.14-alpha/PlinkProxy_v0.0.14-alpha.zip
+Checksum1    = SHA256:33A0720018EA3E6C410404A0A209C81AA4C3014A2FE7DE8AEBC4036373657FB9
 TargetName1  = PlinkProxy
-ExtractName1 = PlinkProxy_v0.0.13-alpha
+ExtractName1 = PlinkProxy_v0.0.14-alpha
+URL2         = https://the.earth.li/~sgtatham/putty/latest/w32/plink.exe
+Checksum2    = SHA256:a474ef7616616b049f3447f63fab271341771cd8fc4211c8f161dad210ffc079
+TargetName2  = PlinkProxy\plink.exe
+ExtractName2 = plink.exe
+URL3         = https://the.earth.li/~sgtatham/putty/latest/w32/pageant.exe
+Checksum3    = SHA256:e1df0058cba346f066489cce1e2928c72fe91b4cc38fcf52198beb5b0be05a92
+TargetName3  = PlinkProxy\pageant.exe
+ExtractName3 = pageant.exe

--- a/App/DefaultData/PlinkProxy.ini
+++ b/App/DefaultData/PlinkProxy.ini
@@ -11,9 +11,9 @@
 ; Login name of the user opening the connection.
 login         = joedoe
 ; Path to the putty binaries. Both `plink.exe` and `pageant.exe` must be present.
-path          = %UserProfile%\PortableApps\PuttyPortable\App\putty
+path          = %ScriptDir%
 ; Path to the ssh private keys in `.ppk` format.
-ssh_keys_dir  = %UserProfile%\PortableApps\PuttyPortable\Data\ssh-keys
+ssh_keys_dir  = %UserProfile%\.ssh
 ; Name of the jump host used for all other connections.
 first_hop     = admin.sample.net
 ; Default plink options used when establishing a connection.


### PR DESCRIPTION
Summary:
  * Upstream release v0.0.14-alpha
  * Including `plink` und `pageant`
    binaries.
  * Change path in default `PlinkProxy.ini`
    file.