### PR TITLE
Beta7: New powershell scripts for binary upgrade

### DIFF
--- a/App/AppInfo/appinfo.ini
+++ b/App/AppInfo/appinfo.ini
@@ -45,5 +45,5 @@ ShellCommand=
 [FileTypeIcons]
 
 [Version]
-PackageVersion=6.0.0.0
-DisplayVersion=0.0.16-alpha-beta6-uroesch
+PackageVersion=0.0.16.2
+DisplayVersion=0.0.16-alpha-beta7-uroesch

--- a/App/AppInfo/update.ini
+++ b/App/AppInfo/update.ini
@@ -1,6 +1,6 @@
 [Version]
-Package = 0.0.16.1
-Display = 0.0.16-alpha-beta6-uroesch
+Package = 0.0.16.2
+Display = 0.0.16-alpha-beta7-uroesch
 
 [Archive]
 URL1         = https://github.com/uroesch/PlinkProxy/releases/download/v0.0.16-alpha/PlinkProxy_v0.0.16-alpha.zip

--- a/Other/Update/PA-Upgrade.ps1
+++ b/Other/Update/PA-Upgrade.ps1
@@ -1,0 +1,91 @@
+# -----------------------------------------------------------------------------
+# Description: Generic Update Script for PortableApps
+# Author: Urs Roesch <github@bun.ch>
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Modules
+# -----------------------------------------------------------------------------
+Using module ".\PortableAppsCommon.psm1"
+
+# -----------------------------------------------------------------------------
+# Globals
+# -----------------------------------------------------------------------------
+$Version    = "0.0.1-alpha"
+$Debug      = $True
+$SiteUrl    = "https://github.com"
+$ReleaseUrl = "$SiteUrl/uroesch/$AppName/releases/"
+
+# -----------------------------------------------------------------------------
+# Functions
+# -----------------------------------------------------------------------------
+Function Fetch-InstallerLink() { 
+  Debug info "Fetching installer download URL"
+  $HtmlContent   = Invoke-WebRequest -Uri $ReleaseUrl
+  $InstallerLink = $(
+    $HtmlContent.Links |
+    Where { $_.href -like "*/download/*exe" } |
+    Select href -First 1
+  ).href
+  $InstallerLink = $SiteUrl + $InstallerLink
+  Debug info "Got installer URL '$InstallerLink'"
+  Return $InstallerLink
+}
+
+# -----------------------------------------------------------------------------
+Function Download-Release {
+  $InstallerLink = Fetch-InstallerLink   
+  $InstallerFile = "$AppRoot/../" + ($InstallerLink.split("/"))[-1]
+
+  If (Test-Path $InstallerFile) { 
+    Debug info "File '$InstallerFile' is already present; Skip download"  
+    Return $InstallerFile
+  }
+
+  Debug info "Downloading Installer from '$InstallerLink'"
+  Try {
+    Invoke-WebRequest `
+      -Uri $InstallerLink `
+      -OutFile $InstallerFile | Out-Null
+  }
+  Catch { 
+    Debug error "Failed to download '$InstallerLink'"
+    Exit 123
+  }
+
+  Return $InstallerFile
+}
+
+# -----------------------------------------------------------------------------
+Function Install-Release() {
+  $Installer = Download-Release
+  Invoke-Installer -Command $Installer
+}
+
+# -----------------------------------------------------------------------------
+Function Invoke-Installer() {
+  param(
+    [string] $Command
+  )
+  Set-Location "$AppRoot\.."
+  $PARoot = (Get-Location)
+
+  Switch (Test-Unix) {
+    $True   {
+      $Arguments = "$Command $(ConvertTo-WindowsPath $PARoot)"
+      $Command   = "wine"
+      break
+    }
+    default {
+      $Arguments = ConvertTo-WindowsPath $PARoot
+    }
+  }
+
+  Debug info "Run PA $Command $Arguments"
+  Start-Process $Command -ArgumentList $Arguments -NoNewWindow -Wait
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+Install-Release

--- a/Other/Update/PortableAppsCommon.psm1
+++ b/Other/Update/PortableAppsCommon.psm1
@@ -8,6 +8,7 @@
 # Globals
 # -----------------------------------------------------------------------------
 $AppRoot        = $(Convert-Path "$PSScriptRoot\..\..")
+$AppName        = (Get-Item $AppRoot).Basename
 $AppDir         = "$AppRoot\App"
 $AppInfoDir     = "$AppDir\AppInfo"
 $AppInfoIni     = "$AppInfoDir\appinfo.ini"
@@ -224,6 +225,7 @@ Export-ModuleMember -Function Compare-Checksum
 Export-ModuleMember -Function Get-Checksum
 Export-ModuleMember -Function Debug
 Export-ModuleMember -Variable AppRoot
+Export-ModuleMember -Variable AppName
 Export-ModuleMember -Variable AppDir
 Export-ModuleMember -Variable AppInfoDir
 Export-ModuleMember -Variable AppInfoIni


### PR DESCRIPTION
Summary:
  * New powershell script `PA-Upgrade.ps1`.
    Downloads and installs the `*.paf.exe` file
    from github.