### PR TITLE
Workflow: Ready build test for ubuntu-20.04

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Cache apt directory cache
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' 
       uses: actions/cache@v2
       env:
         cache-name: cache-apt-pkgs
@@ -43,10 +43,17 @@ jobs:
     - name: Install Wine ~ hick ~
       if: runner.os == 'Linux'
       shell: bash
-      run: >
-        sudo dpkg --add-architecture i386 &&
-        sudo apt-get update &&
-        sudo apt-get -y install wine32
+      run: |2+
+        case $(lsb_release --short --release) in
+        20.04)          
+          sudo apt-get -y install wine
+          ;;
+        18.04)          
+          sudo dpkg --add-architecture i386 &&
+          sudo apt-get update &&
+          sudo apt-get -y install wine32
+          ;;
+        esac
 
     - name: Install Virtual Frame Buffer
       if: runner.os == 'Linux'


### PR DESCRIPTION
Summary:
  * Github Actions will switch ubuntu-latest to
    20.04 in the near future. This change makes
    sure we are not getting caught on the wrong
    foot.